### PR TITLE
Add drag-and-drop template builder interface

### DIFF
--- a/assets/js/dragdrop.js
+++ b/assets/js/dragdrop.js
@@ -1,0 +1,44 @@
+(function(){
+    function enable(list){
+        var items = list.children;
+        for(var i=0;i<items.length;i++){
+            items[i].draggable = true;
+        }
+        list.addEventListener('dragstart', function(e){
+            e.target.classList.add('dragging');
+        });
+        list.addEventListener('dragend', function(e){
+            e.target.classList.remove('dragging');
+        });
+        list.addEventListener('dragover', function(e){
+            e.preventDefault();
+            var dragging = document.querySelector('.dragging');
+            var after = getAfterElement(list, e.clientY);
+            if(after==null){
+                list.appendChild(dragging);
+            }else{
+                list.insertBefore(dragging, after);
+            }
+        });
+    }
+    function getAfterElement(list, y){
+        var els = list.querySelectorAll('.drag-item:not(.dragging)');
+        var closest = null;
+        var closestOffset = Number.NEGATIVE_INFINITY;
+        for(var i=0;i<els.length;i++){
+            var box = els[i].getBoundingClientRect();
+            var offset = y - box.top - box.height/2;
+            if(offset < 0 && offset > closestOffset){
+                closestOffset = offset;
+                closest = els[i];
+            }
+        }
+        return closest;
+    }
+    window.enableDragSort = function(className){
+        var lists = document.getElementsByClassName(className);
+        for(var i=0;i<lists.length;i++){
+            enable(lists[i]);
+        }
+    }
+})();

--- a/post/post_template.php
+++ b/post/post_template.php
@@ -12,21 +12,36 @@ include_once("../core/routeros_api.class.php");
 if(isset($_POST['router_']) && isset($_SESSION["mikhmon"])){
    $do = $_POST['do'];    
     if($do == "saveTemplate"){
-  		$template = $_POST['_template'];
-		$t_file = "../template/".$_POST['file_'];
-		if (is_file($t_file) && !is_writable($t_file)) {
-			    $mess->message = "Error, cannot write config file, please check folder or file permissions.";
-	    		echo json_encode($mess);
-    	}else{
+                $template = $_POST['_template'];
+                $t_file = "../template/".$_POST['file_'];
+                if (is_file($t_file) && !is_writable($t_file)) {
+                            $mess->message = "Error, cannot write config file, please check folder or file permissions.";
+                        echo json_encode($mess);
+        }else{
 
-	        $handle = fopen($t_file, 'w') or die('Cannot open file:  ' . $t_file);
-	        fwrite($handle, $template);
-	      
-			$mess = array(
-				"message" => "Saved"
-			  );
-	    		echo json_encode($mess);
-	    } 
+                $handle = fopen($t_file, 'w') or die('Cannot open file:  ' . $t_file);
+                fwrite($handle, $template);
+
+                        $mess = array(
+                                "message" => "Saved"
+                          );
+                        echo json_encode($mess);
+            }
+    }elseif($do == "saveLayout"){
+                $layout = $_POST['layout_'];
+                $t_file = "../template/".$_POST['file_'];
+                if (is_file($t_file) && !is_writable($t_file)) {
+                            $mess->message = "Error, cannot write config file, please check folder or file permissions.";
+                        echo json_encode($mess);
+        }else{
+                $handle = fopen($t_file, 'w') or die('Cannot open file:  ' . $t_file);
+                fwrite($handle, $layout);
+
+                        $mess = array(
+                                "message" => "Saved"
+                          );
+                        echo json_encode($mess);
+            }
     }
 
 }else{

--- a/template/layout.txt
+++ b/template/layout.txt
@@ -1,0 +1,3 @@
+Header
+Row
+Footer

--- a/view/admin/template_builder.php
+++ b/view/admin/template_builder.php
@@ -1,0 +1,69 @@
+<?php
+session_start();
+// hide all error
+error_reporting(0);
+// protect .php
+$get_self = explode("/",$_SERVER['PHP_SELF']);
+$self[] = $get_self[count($get_self)-1];
+
+if($self[0] !== "index.php"  && $self[0] !==""){
+    include_once("./../../core/route.php");
+}else{
+    include_once('core/routeros_api.class.php');
+    include_once("core/no_cache.php");
+?>
+<link rel="stylesheet" href="./assets/css/editor.min.css">
+<script src="./assets/js/jquery.min.js"></script>
+<script src="./assets/js/dragdrop.js"></script>
+<?php
+if(!isMobile()){
+   $builder_ma = "sidenav_active";
+   include_once("view/header_html.php");
+   include_once("view/menu.php");
+?>
+<div class="main">
+  <div class="row">
+    <div class="col-12">
+      <div class="card card-shadow">
+        <div class="card-header unselect">
+          <span><i class="fa fa-th-large"></i> <b>Template Builder</b></span>&nbsp;&nbsp;|&nbsp;&nbsp;
+          <span class="pointer" id="btn-save"><i class="fa fa-save"></i> Save</span>
+          <span id="tb_loading"></span>
+        </div>
+        <div class="card-body">
+          <div class="row">
+            <div class="col-md-6">
+              <h5>Layout</h5>
+              <ul id="layout" class="draggable list-group">
+                <li class="list-group-item drag-item">Header</li>
+                <li class="list-group-item drag-item">Row</li>
+                <li class="list-group-item drag-item">Footer</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<script>
+$(document).ready(function(){
+    enableDragSort('draggable');
+    $('#btn-save').click(function(){
+        var layout = $('#layout').html();
+        $.post('./post/post_template.php', {
+            router_: '1',
+            do: 'saveLayout',
+            layout_: layout,
+            file_: 'layout.txt'
+        }, function(res){
+            if(res && res.message){
+                alert(res.message);
+            }
+        }, 'json');
+    });
+});
+</script>
+<?php }
+}
+?>


### PR DESCRIPTION
## Summary
- Add lightweight drag-drop utility library
- Introduce new Template Builder admin page with drag-and-drop layout and save option
- Extend post handler to save new layout files and add default layout

## Testing
- `php -l view/admin/template_builder.php`
- `php -l post/post_template.php`


------
https://chatgpt.com/codex/tasks/task_b_6898ec774fe08333b969c06548e9dfa6