### PR TITLE
Add expiry date and support info to voucher templates

### DIFF
--- a/template/row.default.txt
+++ b/template/row.default.txt
@@ -15,15 +15,16 @@
 		</tr>
 		<tr>
 			<td style="font-size: 10px;">
-				<span class="validity">%validity%</span> 
-				<span class="timelimit">%limitUptime%</span> 
-				<span>%limitBytesTotal%</span>
-			</td>
-		</tr>
-		<tr>
-			<td colspan="3" style="font-size: 10px;">Login: http://%dnsName% <span class="num"> [%#%]</span></td>
-		</tr>
-	</tbody>
+                                <span class="validity">%validity%</span>
+                                <span class="timelimit">%limitUptime%</span>
+                                <span>%limitBytesTotal%</span>
+                                <span class="expiryDate">%expiryDate%</span>
+                        </td>
+                </tr>
+                <tr>
+                        <td colspan="3" style="font-size: 10px;">Login: http://%dnsName% <span class="num"> [%#%]</span><br>Support: %phone%</td>
+                </tr>
+        </tbody>
 </table>
 <script>
 	if("%username%" == "%password%"){

--- a/template/row.small.txt
+++ b/template/row.small.txt
@@ -16,11 +16,14 @@
 			<td class="up" style="border: 1px solid black; font-weight:bold;display:none;">%password%</td>
 		</tr>
 	</tbody>
-	<tfoot>
-		<tr style="color: black; font-size: 10px; text-align: center;">
-			<th colspan="2" ><span class="validity">%validity%</span> <span class="timelimit">%limitUptime%</span> <span>%limitBytesTotal%</span> <span class="price">%price%</span></th>
-		</tr>
-	</tfoot>
+        <tfoot>
+                <tr style="color: black; font-size: 10px; text-align: center;">
+                        <th colspan="2" ><span class="validity">%validity%</span> <span class="timelimit">%limitUptime%</span> <span>%limitBytesTotal%</span> <span class="expiryDate">%expiryDate%</span> <span class="price">%price%</span></th>
+                </tr>
+                <tr style="color: black; font-size: 10px; text-align: center;">
+                        <th colspan="2">Support: %phone%</th>
+                </tr>
+        </tfoot>
 </table>
 <script>
 	if("%username%" == "%password%"){

--- a/template/row.thermal.txt
+++ b/template/row.thermal.txt
@@ -34,9 +34,9 @@
 							</td>
 						</tr>
 
-						<tr>
-							<td colspan="2" style="border-top: 1px solid black;font-weight:bold; font-size:14px"><span class="validity">%validity%</span> <span class="timelimit">%limitUptime%</span> <span>%limitBytesTotal%</span></td>
-						</tr>
+                                                <tr>
+                                                        <td colspan="2" style="border-top: 1px solid black;font-weight:bold; font-size:14px"><span class="validity">%validity%</span> <span class="timelimit">%limitUptime%</span> <span>%limitBytesTotal%</span> <span class="expiryDate">%expiryDate%</span></td>
+                                                </tr>
 						<tr>
 							<td><span class="price">%price%</span></td>
 						</tr>
@@ -46,13 +46,16 @@
 								%comment%
 							</td>
 						</tr>
-						<tr>
-							<td colspan="2" style="font-weight:bold; font-size:12px">Login: http://%dnsName%</td>
-						</tr>
-					</tbody>
-				</table>
-			</td>
-		</tr>
+                                                <tr>
+                                                        <td colspan="2" style="font-weight:bold; font-size:12px">Login: http://%dnsName%</td>
+                                                </tr>
+                                                <tr>
+                                                        <td colspan="2" style="font-weight:bold; font-size:12px">Support: %phone%</td>
+                                                </tr>
+                                        </tbody>
+                                </table>
+                        </td>
+                </tr>
 	</tbody>
 </table>
 <script>

--- a/view/print_voucher.php
+++ b/view/print_voucher.php
@@ -42,6 +42,24 @@ echo '
 
 $timestamp =  date("Y-m-d H:i:s");
 
+function expiryDate($validity, $timestamp){
+  $pattern = '/(\d+)([smhdw])/';
+  if(preg_match($pattern, $validity, $matches)){
+    $value = (int)$matches[1];
+    $unit = $matches[2];
+    switch($unit){
+      case 's': $seconds = $value; break;
+      case 'm': $seconds = $value * 60; break;
+      case 'h': $seconds = $value * 3600; break;
+      case 'd': $seconds = $value * 86400; break;
+      case 'w': $seconds = $value * 604800; break;
+      default: $seconds = 0; break;
+    }
+    return date("Y-m-d", strtotime($timestamp) + $seconds);
+  }
+  return "";
+}
+
 $logo = "./assets/img/logo-" . $m_user . ".png";
 if (file_exists($logo)) {
   $logo = "./assets/img/logo-" . $m_user . ".png?".date("YmdHis");
@@ -170,10 +188,10 @@ include_once("config/connection.php");
         })();
       </script>
       ";
-   
-    $num = $i + 1;
 
-  
+    $num = $i + 1;
+      $expiry = expiryDate($validity, $timestamp);
+
       $template = file_get_contents("$row");
      echo str_replace("%username%", $username,
           str_replace("%password%", $password,
@@ -181,20 +199,21 @@ include_once("config/connection.php");
           str_replace("%limitBytesTotal%", $datalimit,
           str_replace("%limitUptime%", $timelimit,
           str_replace("%validity%", $validity,
+          str_replace("%expiryDate%", $expiry,
           str_replace("%price%", $getsprice,
           str_replace("%comment%", $comment,
           str_replace("%#%", $num,
           str_replace("%dnsName%", $dnsname,
           str_replace("%hotspotName%", $hotspotname,
-          str_replace("%currency%", $currency, 
-          str_replace("%qrCode%", $qrcode, 
-          str_replace("%qrCodeRed%", $qrcodeR, 
+          str_replace("%currency%", $currency,
+          str_replace("%qrCode%", $qrcode,
+          str_replace("%qrCodeRed%", $qrcodeR,
           str_replace("%qrCodeGreen%", $qrcodeG, 
-          str_replace("%qrCodeBlue%", $qrcodeB, 
+          str_replace("%qrCodeBlue%", $qrcodeB,
           str_replace("%phone%", $phone,
           str_replace("%logo%", $logo,
           str_replace("%timeStamp%", $timestamp,
-          $template)))))))))))))))))));
+          $template))))))))))))))))))));
      
   
     }


### PR DESCRIPTION
## Summary
- show voucher expiry date automatically computed from validity period
- include support contact in all voucher templates

## Testing
- `php -l view/print_voucher.php`


------
https://chatgpt.com/codex/tasks/task_b_6898e00b06208333865755f9b0d8a7ea